### PR TITLE
Add per-component resource configuration for CariData chart

### DIFF
--- a/charts/caridata/README.md
+++ b/charts/caridata/README.md
@@ -6,3 +6,35 @@ This Helm chart deploys the CariData backend and frontend applications along wit
 ## Installation
 ```bash
 helm install caridata charts/caridata
+```
+
+## Configuration
+
+### Resource management
+
+Both the backend and frontend deployments expose dedicated `resources` sections so you can
+define CPU and memory requests and limits according to Kubernetes best practices. Each
+component ships with sensible defaults that request a portion of the available resources
+while still defining upper limits to protect the cluster.
+
+Example override file:
+
+```yaml
+backend:
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: 1
+      memory: 1Gi
+
+frontend:
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 400m
+      memory: 512Mi
+```

--- a/charts/caridata/templates/deployment-backend.yaml
+++ b/charts/caridata/templates/deployment-backend.yaml
@@ -56,8 +56,10 @@ spec:
             httpGet:
               path: /docs
               port: 8000
+          {{- with .Values.backend.resources }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/caridata/templates/deployment-frontend.yaml
+++ b/charts/caridata/templates/deployment-frontend.yaml
@@ -42,8 +42,10 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.service.port }}
+          {{- with .Values.frontend.resources }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             {{- range $key, $value := .Values.frontend.ENV }}
             - name: {{ $key }}

--- a/charts/caridata/values.yaml
+++ b/charts/caridata/values.yaml
@@ -13,6 +13,13 @@ backend:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   existingSecret: ""
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 256Mi
   secrets:
     API_ENVIRONMENT__ENVIRONMENT: ""
     API_SCALEWAY__PROJECT_ID: ""
@@ -41,8 +48,16 @@ backend:
     API_CARITAS__API_BASIC_AUTH_PASSWORD: ""
 
 frontend:
+  replicaCount: 1
   image:
   pullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 300m
+      memory: 256Mi
+    requests:
+      cpu: 150m
+      memory: 128Mi
   ENV:
     VITE_BASE_URL: "/uploads"
     VITE_API_BASE_URL: "uploads/api"
@@ -84,14 +99,6 @@ ingress:
   #  - secretName: chart-example-tls
 #    hosts:
         #      - chart-example.local
-
-resources:
-  limits:
-    cpu: 500m
-    memory: 512Mi
-  requests:
-    cpu: 250m
-    memory: 256Mi
 
 nodeSelector: {}
 


### PR DESCRIPTION
## Summary
- expose resource requests and limits for the backend deployment with sensible defaults
- add configurable resource requests, limits, and replica count defaults for the frontend deployment
- document the resource configuration options in the chart README

## Testing
- not run (Helm CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_690a152d25e483329f848b926f71fed3