### PR TITLE
Align replica counts across deployments

### DIFF
--- a/charts/caridata/templates/deployment-backend.yaml
+++ b/charts/caridata/templates/deployment-backend.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "common.labels" . | nindent 4 }}
     tier: backend
 spec:
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "common.selectorLabels" . | nindent 6 }}

--- a/charts/caridata/templates/deployment-frontend.yaml
+++ b/charts/caridata/templates/deployment-frontend.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "common.labels" . | nindent 4 }}
     tier: frontend
 spec:
-  replicas: {{ .Values.frontend.replicaCount }}
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "common.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
## Summary
- update the frontend deployment to use the chart-level replicaCount value
- add the replicaCount setting to the backend deployment for consistency

## Testing
- `helm template test charts/caridata` *(fails in container: helm binary not available)*

------
https://chatgpt.com/codex/tasks/task_e_690a1ef8a93c8332af817f93eb66ec2b