### PR TITLE
Allow backend deployment to use existing secret

### DIFF
--- a/charts/caridata/templates/deployment-backend.yaml
+++ b/charts/caridata/templates/deployment-backend.yaml
@@ -42,8 +42,8 @@ spec:
           - '8000'
           - '--access-log'
           envFrom:
-           - secretRef:
-              name: {{ printf "secrets-backend%s" .Release.Name  }}
+            - secretRef:
+                name: {{ default (printf "secrets-backend%s" .Release.Name) .Values.backend.existingSecret }}
           ports:
             - name: http
               containerPort: 8000


### PR DESCRIPTION
## Summary
- update the backend deployment secretRef to use an existing secret name when provided
- retain the backend secret template behind the existingSecret guard so only one secret name is referenced

## Testing
- helm template test charts/caridata *(fails: helm is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_690a1ee50ce88332b53df25fb0ab122d