### PR TITLE
feat: run alembic migrations before backend startup

### DIFF
--- a/charts/caridata/README.md
+++ b/charts/caridata/README.md
@@ -38,3 +38,12 @@ frontend:
       cpu: 400m
       memory: 512Mi
 ```
+
+### Database migrations
+
+The backend deployment runs database migrations before starting the application by using an
+init container that executes `alembic upgrade head`. You can customise the behaviour through
+the `backend.migrations` values. By default the init container reuses the backend image and
+pull policy, but you can provide overrides for the command, arguments, environment variables
+or container resources when needed. Disable the init container entirely by setting
+`backend.migrations.enabled` to `false`.

--- a/charts/caridata/templates/deployment-backend.yaml
+++ b/charts/caridata/templates/deployment-backend.yaml
@@ -25,6 +25,47 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- $backendValues := .Values.backend }}
+      {{- $migrations := $backendValues.migrations }}
+      {{- $migrationsEnabled := true }}
+      {{- if and $migrations (hasKey $migrations "enabled") }}
+      {{- $migrationsEnabled = $migrations.enabled }}
+      {{- end }}
+      {{- if and $migrations $migrationsEnabled }}
+      initContainers:
+        - name: {{ default "alembic-migrate" $migrations.name }}
+          image: {{ default $backendValues.image $migrations.image }}
+          {{- with (default $backendValues.pullPolicy $migrations.pullPolicy) }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
+          {{- with $migrations.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- else }}
+          command:
+            - alembic
+            - upgrade
+            - head
+          {{- end }}
+          {{- with $migrations.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ printf "secrets-backend%s" .Release.Name  }}
+            {{- with $migrations.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with $migrations.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $migrations.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -42,8 +83,8 @@ spec:
           - '8000'
           - '--access-log'
           envFrom:
-           - secretRef:
-              name: {{ printf "secrets-backend%s" .Release.Name  }}
+            - secretRef:
+                name: {{ printf "secrets-backend%s" .Release.Name  }}
           ports:
             - name: http
               containerPort: 8000

--- a/charts/caridata/values.yaml
+++ b/charts/caridata/values.yaml
@@ -13,6 +13,16 @@ backend:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   existingSecret: ""
+  migrations:
+    enabled: true
+    name: alembic-migrate
+    image: ""
+    pullPolicy: ""
+    command: []
+    args: []
+    env: []
+    extraEnvFrom: []
+    resources: {}
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
## Summary
- add an init container to the backend deployment to run `alembic upgrade head`
- expose configurable `backend.migrations` values to tune the migration job
- document the migration behaviour and configuration in the chart README

## Testing
- `helm lint charts/caridata` *(fails: helm is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_690a204b4e748332a84d93ba7ee9626f