### PR TITLE
Respect provided backend secret names

### DIFF
--- a/charts/caridata/README.md
+++ b/charts/caridata/README.md
@@ -47,3 +47,11 @@ the `backend.migrations` values. By default the init container reuses the backen
 pull policy, but you can provide overrides for the command, arguments, environment variables
 or container resources when needed. Disable the init container entirely by setting
 `backend.migrations.enabled` to `false`.
+
+### Backend secrets
+
+Populate the `backend.secrets` map with the environment variables that should be exposed to
+the application. When Helm manages the Kubernetes secret, the chart now honours the
+`backend.secretName` value verbatim, ensuring no prefixes or suffixes are added. Set
+`backend.existingSecret` instead when you want to reference a pre-existing secret and skip
+rendering a new one.

--- a/charts/caridata/templates/deployment-backend.yaml
+++ b/charts/caridata/templates/deployment-backend.yaml
@@ -1,3 +1,4 @@
+{{- $backendSecretName := .Values.backend.existingSecret | default (.Values.backend.secretName | default .Release.Name) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,7 +55,7 @@ spec:
           {{- end }}
           envFrom:
             - secretRef:
-                name: {{ printf "secrets-backend%s" .Release.Name  }}
+                name: {{ $backendSecretName }}
             {{- with $migrations.extraEnvFrom }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -85,7 +86,7 @@ spec:
           - '--access-log'
           envFrom:
             - secretRef:
-                name: {{ default (printf "secrets-backend%s" .Release.Name) .Values.backend.existingSecret }}
+                name: {{ $backendSecretName }}
           ports:
             - name: http
               containerPort: 8000

--- a/charts/caridata/templates/secrets-backend.yaml
+++ b/charts/caridata/templates/secrets-backend.yaml
@@ -1,8 +1,9 @@
 {{- if not .Values.backend.existingSecret }}
+{{- $secretName := .Values.backend.secretName | default .Release.Name }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "secrets-backend%s" .Release.Name  }}
+  name: {{ $secretName }}
 data:
   {{- range $key, $val := .Values.backend.secrets }}
   {{ $key }}: {{ $val | b64enc | quote }}

--- a/charts/caridata/values.yaml
+++ b/charts/caridata/values.yaml
@@ -13,6 +13,7 @@ backend:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   existingSecret: ""
+  secretName: ""
   migrations:
     enabled: true
     name: alembic-migrate


### PR DESCRIPTION
## Summary
- allow configuring the backend secret name without adding prefixes or suffixes
- reference the same configured secret for both the init and main backend containers
- document how to configure backend secrets in the chart values

## Testing
- ⚠️ `helm lint charts/caridata` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_690a54fb491c83329601d8ce5c56bf2b